### PR TITLE
Remove broken demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,6 @@ Directory tree
     └── templates
         └── index.html
 
-Example Sites
---------------
-[Personal Site](https://icyphox.sh/) | [(Git)](https://github.com/icyphox/site)
-
 TODO
 ----
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # vite
 > A simple and mnml static site generator that Just Works™
 
-<h1 align="center">
-    <img width="750" src="https://0x0.st/swPG.png" alt="Vite demo">
-</h1>
-
 Installation
 ------------
 
@@ -98,6 +94,10 @@ Directory tree
     ├── static
     └── templates
         └── index.html
+
+Example Sites
+--------------
+[Personal Site](https://icyphox.sh/) | [(Git)](https://github.com/icyphox/site)
 
 TODO
 ----


### PR DESCRIPTION
Just linked to your website since the demo's image as well as the link it points to both no longer work.